### PR TITLE
docs: update the build example doc (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Angular CLI builders that delegate to Bazel under-the-hood.
         "build": {
           "builder": "bazel-cli-builders:build",
           "options": {
+            "bazelCommand": "build",
             "targetLabel": "//src:src"
           },
-          "configurations": {}
         },
 ```


### PR DESCRIPTION
The builder schema requires a `bazelCommand` to be provided.